### PR TITLE
[DOCS-215, DOCS-244] Add onStart() and onStop()

### DIFF
--- a/android-3.x.x/docs/usage/jwplayer-view.md
+++ b/android-3.x.x/docs/usage/jwplayer-view.md
@@ -64,8 +64,6 @@ In order to properly handle the Activity Lifecycle and release the player from m
 - `onStart()`
 - `onStop()`
 
-Review the code example below.
-
 ```java
  @Override
 protected void onStart() {


### PR DESCRIPTION
## SDK documentation PR

### What does this Pull Request do?
- Adds requirement to override `onStop()` and `onStart()`.
- Places methods in a list.
- Updates the code sample to match the example linked here: https://jwplayer.atlassian.net/browse/AB-1882
- Moves note that this is not required for `JWPlayerFragment` or `JWPlayerSupportFragment` into a NOTES box.
- Adds a _Last Updated_ date to the developer article.

### Why is this Pull Request needed?
- If a developer doesn't call these methods, the player will remain alive when backgrounding the app or activity

### By what date must this update be published?
- March 14, 2019

### Are there any points in the code the reviewer needs to double check?
- Confirm that the code sample is accurate.
- Confirm that this is the appropriate location for this update.

### Are there any Pull Requests open in other repos which need to be merged with this?
- No.

#### Related Jira ticket(s):

- DOCS-215
- DOCS-244

Do not forget to tag @kcorneli201 and at least one other reviewer.
