### PR TITLE
Updated error in release notes for v 2.8.10

### DIFF
--- a/ios-3.x.x/docs/about/release-notes.md
+++ b/ios-3.x.x/docs/about/release-notes.md
@@ -143,7 +143,7 @@ You may use CocoaPods to update to SDK 3.x, or you can download the SDK 3 packag
 * Fixed an issue where the app would crash if there was a problem with local player related files creation
 
 ### Enhancements
-* Upgraded to support Google IMA SDK v3.7.0
+* Upgraded to support Google IMA SDK v3.3.1
 
 <a name="2-8-9"></a>
 ## Version 2.8.9 (Build 47 - Apr 16, 2018)


### PR DESCRIPTION
v2.8.10 had the incorrect IMA SDK library reported. I updated it to the correct version of Google IMA SDK v3.3.1
FYI
@henryhlee @karimMourra @mikesalvia @kcorneli201
