### PR TITLE
Expired key UX improvement note

### DIFF
--- a/ios-3.x.x/docs/about/release-notes.md
+++ b/ios-3.x.x/docs/about/release-notes.md
@@ -30,7 +30,7 @@
 * Added Fairplay DRM support for Airplay
 * Changed the Enums to NS_ENUM for better type-checking
 * Added `onWarning` callback for non-fatal error debugging or troubleshooting purposes
-* Improved expired JW Player license key user experience. Now if a JW Player license key is expired an error message is sent and the player in the app will not start/setup.
+* Improved JW Player expired license user experience by adding an error message notification and halting player setup or playback
 
 ### Fixes
 * Fixed an issue where the `onAdSchedule` callback would not fire for VMAP ads


### PR DESCRIPTION
Added SDK-4081 (Expired JW Player Key UX Improvement) to iOS 3.3.0 release notes. It was marked in jira for a future release but ended up actually being merged and released in 3.3.0 release.

FYI @karimMourra @henryhlee @kcorneli201 